### PR TITLE
Fix use of sycl::buffer_allocator due to SYCL API change in 5.7.0

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h
@@ -207,6 +207,13 @@ constexpr __target __target_device =
     __target::global_buffer;
 #endif
 
+using __buffer_allocator =
+#if __LIBSYCL_VERSION >= 50700
+    sycl::buffer_allocator<char>;
+#else
+    sycl::buffer_allocator;
+#endif
+
 } // namespace __dpl_sycl
 
 #endif /* _ONEDPL_sycl_defs_H */

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_iterator.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_iterator.h
@@ -31,7 +31,7 @@ namespace __internal
 {
 // Iterator that hides sycl::buffer to pass those to algorithms.
 // SYCL iterator is a pair of sycl::buffer and integer value
-template <access_mode Mode, typename T, typename Allocator = sycl::buffer_allocator>
+template <access_mode Mode, typename T, typename Allocator = __dpl_sycl::__buffer_allocator>
 struct sycl_iterator
 {
   private:


### PR DESCRIPTION
Tests in oneDPL do not compile with the newest version of intel/llvm due to an API change for their SYCL implementation.

The SYCL 2020 spec states that `sycl::buffer_allocator<T>` is a class template that takes a single template parameter for the data type of the buffer. However, the libsycl implementation prior to 5.7.0 has this class as non-templated. This was changed (commit https://github.com/intel/llvm/commit/53430c83bf9d1d82cb3578500290a26b61153b82) to a class template to correctly reflect the spec and was made into a breaking change for 5.7.0 in commit https://github.com/intel/llvm/commit/78275902fd56cf78c1703453c1e8bc01b859f60f.

This API change breaks the usage of `sycl::buffer_allocator` in oneDPL. This PR provides the two implementations and selects the appropriate implementation based on the `__LIBSYCL_VERSION` define.